### PR TITLE
fix install encoding error on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf8').read()
 
 setup(
     name='django-micro',


### PR DESCRIPTION
When install this package on Windows, an encoding error occurs. Adding encoding='utf8' to open function in setup.py can fix it. 

Detail:
D:\workspace\Python\github>pip install django-micro
Collecting django-micro
  Downloading https://files.pythonhosted.org/packages/7e/ac/1a46a24af5806910f4eb055587db87d66fb7995e7a8515c90eb7c861ebc5/djan
go-micro-1.7.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\ADMINI~1\AppData\Local\Temp\pip-build-pfokkowo\django-micro\setup.py", line 10, in <module>
        long_description=read('README.rst'),
      File "C:\Users\ADMINI~1\AppData\Local\Temp\pip-build-pfokkowo\django-micro\setup.py", line 5, in read
        return open(os.path.join(os.path.dirname(__file__), fname)).read()
    UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 4943: illegal multibyte sequence

Command "python setup.py egg_info" failed with error code 1 in C:\Users\ADMINI~1\AppData\Local\Temp\pip-build-pfokkowo\django
-micro\
 
